### PR TITLE
Git stash before checking out to target branch

### DIFF
--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -11,7 +11,6 @@ git_setup() {
 EOF
   chmod 600 $HOME/.netrc
 
-  git config --global core.excludesfile ~/.gitignore_global # gitignore
   git config --global user.email "$GITHUB_ACTOR@users.noreply.github.com"
   git config --global user.name "$GITHUB_ACTOR"
 }
@@ -20,12 +19,15 @@ git_setup
 git remote update
 git fetch --all
 
+git config --global core.excludesfile ~/.gitignore_global # gitignore
+
 # Will create branch if it does not exist
 if [[ $( git branch -r | grep "$INPUT_BRANCH" ) ]]; then
    git checkout "${INPUT_BRANCH}"
 else
    git checkout -b "${INPUT_BRANCH}"
 fi
+
 git add .
 git commit -m "${INPUT_COMMIT_MESSAGE}"
 git push --set-upstream origin "${INPUT_BRANCH}"

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -25,7 +25,7 @@ if [[ $( git branch -r | grep "$INPUT_BRANCH" ) ]]; then
 else
    git checkout -b "${INPUT_BRANCH}"
 fi
-git rm -r --cached . # Clear in case .gitignore has changed
+git config --global core.excludesfile ~/.gitignore_global # gitignore
 git add .
 git commit -m "${INPUT_COMMIT_MESSAGE}"
 git push --set-upstream origin "${INPUT_BRANCH}"

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -19,7 +19,7 @@ git_setup
 git remote update
 git fetch --all
 
-git config --global core.excludesfile ~/.gitignore_global # gitignore
+git stash
 
 # Will create branch if it does not exist
 if [[ $( git branch -r | grep "$INPUT_BRANCH" ) ]]; then
@@ -28,6 +28,7 @@ else
    git checkout -b "${INPUT_BRANCH}"
 fi
 
+git stash pop
 git add .
 git commit -m "${INPUT_COMMIT_MESSAGE}"
 git push --set-upstream origin "${INPUT_BRANCH}"

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -25,7 +25,7 @@ if [[ $( git branch -r | grep "$INPUT_BRANCH" ) ]]; then
 else
    git checkout -b "${INPUT_BRANCH}"
 fi
-
+git rm -r --cached . # Clear in case .gitignore has changed
 git add .
 git commit -m "${INPUT_COMMIT_MESSAGE}"
 git push --set-upstream origin "${INPUT_BRANCH}"

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -11,6 +11,7 @@ git_setup() {
 EOF
   chmod 600 $HOME/.netrc
 
+  git config --global core.excludesfile ~/.gitignore_global # gitignore
   git config --global user.email "$GITHUB_ACTOR@users.noreply.github.com"
   git config --global user.name "$GITHUB_ACTOR"
 }
@@ -25,7 +26,6 @@ if [[ $( git branch -r | grep "$INPUT_BRANCH" ) ]]; then
 else
    git checkout -b "${INPUT_BRANCH}"
 fi
-git config --global core.excludesfile ~/.gitignore_global # gitignore
 git add .
 git commit -m "${INPUT_COMMIT_MESSAGE}"
 git push --set-upstream origin "${INPUT_BRANCH}"


### PR DESCRIPTION
If the changes modify .gitignore, they need to be `stash`ed before checking out, otherwise you get an error and the build fails. 