### PR TITLE
Updating the example usage

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,10 +16,13 @@ Custom commit message. **default** "Automated commit from action""
 
 ## Example usage
 ```
+- name: Set branch env var
+  run: echo ::set-env name=BUILT_BRANCH::${GITHUB_REF##*/}-built
+  
 - name: Push to built branch
   uses: Automattic/action-commit-to-branch@master
   with:
-    branch: 'master-built'
+    branch: ${{ env.BUILT_BRANCH }}
     commit_message: 'Build master'
   env:
     GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }} # Required


### PR DESCRIPTION
This is to show users how to push to the respective built branch.
Example:
I don't want my changes to develop or preprod to push to master-built and get deployed to the live site. Those should go to develop-built or preprod-built respectively so they deploy to the correct environments.