### PR TITLE
Include untracked files in stash

### DIFF
--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -19,7 +19,7 @@ git_setup
 git remote update
 git fetch --all
 
-git stash
+git stash --include-untracked
 
 # Will create branch if it does not exist
 if [[ $( git branch -r | grep "$INPUT_BRANCH" ) ]]; then


### PR DESCRIPTION
When stashing files, there may be generated files that aren't tracked yet on the current branch. Make sure we include those in the stash before checkout out another branch on which those files might be tracked.